### PR TITLE
Update for unix-errno 0.4.0 fixing a potential readdir bug

### DIFF
--- a/lib_gen/unix_dirent_bindings.ml
+++ b/lib_gen/unix_dirent_bindings.ml
@@ -23,13 +23,19 @@ let dirent = Types.Dirent.t
 
 let dir_handle = Ctypes.(
   view
-    ~read:(fun ptr ->
-        Unix_representations.dir_handle_of_nativeint
-          (raw_address_of_ptr ptr))
-    ~write:(fun dir ->
-        ptr_of_raw_address
-          (Unix_representations.nativeint_of_dir_handle dir))
-    (ptr void))
+    ~read:(function
+      | Some ptr ->
+        Some (Unix_representations.dir_handle_of_nativeint
+                (raw_address_of_ptr ptr))
+      | None -> None
+    )
+    ~write:(function
+      | Some dir ->
+        Some (ptr_of_raw_address
+                (Unix_representations.nativeint_of_dir_handle dir))
+      | None -> None
+    )
+    (ptr_opt void))
 
 module C(F: Cstubs.FOREIGN) = struct
 


### PR DESCRIPTION
Previously, errors during `readdir` would result in `End_of_file` rather than an error condition.