### PR TITLE
Locally-open 'F' in each 'foreign' binding.

### DIFF
--- a/lib_gen/unix_dirent_bindings.ml
+++ b/lib_gen/unix_dirent_bindings.ml
@@ -40,12 +40,12 @@ let dir_handle = Ctypes.(
 module C(F: Cstubs.FOREIGN) = struct
 
   let opendir =
-    F.foreign "unix_dirent_opendir" (string @-> returning dir_handle)
+    F.(foreign "unix_dirent_opendir" (string @-> returning dir_handle))
 
   let readdir =
-    F.foreign "unix_dirent_readdir" (dir_handle @-> returning (ptr_opt dirent))
+    F.(foreign "unix_dirent_readdir" (dir_handle @-> returning (ptr_opt dirent)))
 
   let closedir =
-    F.foreign "unix_dirent_closedir" (dir_handle @-> returning int)
+    F.(foreign "unix_dirent_closedir" (dir_handle @-> returning int))
 
 end


### PR DESCRIPTION
Prepare the bindings in case some future version of ctypes adds `@->` and `returning` to the `Cstubs.FOREIGN` signature.