### PR TITLE
Updates for unix-errno 0.5.0

### DIFF
--- a/lwt/dirent_unix_lwt.ml
+++ b/lwt/dirent_unix_lwt.ml
@@ -30,7 +30,7 @@ let kind_of_code kind_code =
 
 let readdir handle =
   (C.readdir (Some handle)).Generated.lwt >>= function
-    None, 0 -> Lwt.fail End_of_file
+    None, errno when errno = Signed.SInt.zero -> Lwt.fail End_of_file
   | None, errno -> lwt_raise_errno_error ~call:"readdir" errno
                      ~label:(Nativeint.to_string
                                (Unix_representations.nativeint_of_dir_handle handle))

--- a/opam
+++ b/opam
@@ -30,6 +30,6 @@ depopts: [
 ]
 conflicts: [
   "ctypes" {< "0.6.0"}
-  "unix-errno" {< "0.4.0"}
+  "unix-errno" {< "0.5.0"}
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/unix/dirent_unix.ml
+++ b/unix/dirent_unix.ml
@@ -42,7 +42,7 @@ let opendir name =
 
 let readdir dirh =
   match C.readdir (Some dirh) with
-  | None, 0 -> raise End_of_file
+  | None, errno when errno = Signed.SInt.zero -> raise End_of_file
   | None, errno -> Errno_unix.raise_errno ~call:"readdir" errno
   | Some t, _ ->
     let open Ctypes in


### PR DESCRIPTION
`errno` is now a `sint` not an `int`.